### PR TITLE
Replace colorant"dark gray" with colorant"darkgray"

### DIFF
--- a/src/window.jl
+++ b/src/window.jl
@@ -92,8 +92,8 @@ mutable struct Scene{T <: AbstractVector{<:AbstractLayer}} <: AbstractScene{T}
     color::Colors.RGB
 end
 
-Scene(layer::AbstractLayer, layers::AbstractLayer...; color=Colors.colorant"dark gray") = Scene([layer, layers...], color)
-Scene(layers::T) where {T<:AbstractVector{<:AbstractLayer}} = Scene(layers, Colors.colorant"dark gray")
+Scene(layer::AbstractLayer, layers::AbstractLayer...; color=Colors.colorant"darkgray") = Scene([layer, layers...], color)
+Scene(layers::T) where {T<:AbstractVector{<:AbstractLayer}} = Scene(layers, Colors.colorant"darkgray")
 
 struct RenderTask{T}
     source::T


### PR DESCRIPTION
To remove this warning:

```julia
┌ Warning: The X11 color names with spaces are not recommended because they are not allowed in the SVG/CSS.
│ Use "DarkGray" or "darkgray" instead.
│   caller = @colorant_str(::LineNumberNode, ::Module, ::Any) at parse.jl:192
└ @ Colors ~/.julia/packages/Colors/P2rUx/src/parse.jl:192
```